### PR TITLE
新增 Surgio 支持

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # direct-android-ruleset
 
-帮 Android 手机绕开国产 App 的包名合集。规则基于多个应用市场榜单自动抓取包名生成，每天自动更新🍃
+帮 Android 手机绕开国产 App 的包名合集。规则基于多个应用市场榜单自动抓取包名生成，每天自动更新 🍃
 
 ## 食用方法
 
@@ -23,6 +23,40 @@ rules:
 ```
 
 如果你发现你访问不了 `github.com`，自己想办法套个 jsDelivr CDN 之类的。
+
+### Surgio
+
+在 `surgio.conf.js` 中配置远程模板片段
+
+```javascript
+module.exports = {
+  remoteSnippets: [
+    ...,
+    {
+      name: "chinaApps",
+      url: 'https://github.com/mnixry/direct-android-ruleset/raw/refs/heads/rules/@Merged/APP.mutated.yaml',
+      surgioSnippet: true
+    },
+    {
+      name: "chinaGames",
+      url: 'https://github.com/mnixry/direct-android-ruleset/raw/refs/heads/rules/@Merged/GAME.mutated.yaml',
+      surgioSnippet: true
+    },
+  ],
+};
+```
+
+然后在模板规则里引用远程模板片段（以 `clash.tpl` 为例）
+
+```yaml
+rules:
+{% filter clash %}
+{{ remoteSnippet.chinaApps.main('DIRECT') }}
+{{ remoteSnippet.chinaGames.main('DIRECT') }}
+{% endfilter %}
+```
+
+详情参考 [Surgio 文档](https://surgio.js.org/guide/custom-template.html#%E5%A6%82%E4%BD%95%E4%BD%BF%E7%94%A8%E7%89%87%E6%AE%B5)。
 
 ### Others
 

--- a/README.md
+++ b/README.md
@@ -34,12 +34,12 @@ module.exports = {
     ...,
     {
       name: "chinaApps",
-      url: 'https://github.com/mnixry/direct-android-ruleset/raw/refs/heads/rules/@Merged/APP.mutated.yaml',
+      url: 'https://github.com/mnixry/direct-android-ruleset/raw/refs/heads/rules/@Merged/APP.mutated.tpl',
       surgioSnippet: true
     },
     {
       name: "chinaGames",
-      url: 'https://github.com/mnixry/direct-android-ruleset/raw/refs/heads/rules/@Merged/GAME.mutated.yaml',
+      url: 'https://github.com/mnixry/direct-android-ruleset/raw/refs/heads/rules/@Merged/GAME.mutated.tpl',
       surgioSnippet: true
     },
   ],

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,7 +47,7 @@ const rulesToSurgioSnippet = (
   for (const [pkgName, name] of Object.entries(rules).sort(([ka], [kb]) =>
     ka.localeCompare(kb)
   )) {
-    const comment = name ? ` {# ${name} #}` : "";
+    const comment = name ? ` # ${name}` : "";
     snippets.push(`PROCESS-NAME,${pkgName},{{ rule }}${comment}`);
   }
 
@@ -55,8 +55,8 @@ const rulesToSurgioSnippet = (
     for (const include of includes) {
       snippets.push(
         typeof include === "string"
-          ? `PROCESS-NAME,${include}`
-          : `PROCESS-NAME-REGEX,${include.regex}`
+          ? `PROCESS-NAME,${include},{{ rule }}`
+          : `PROCESS-NAME-REGEX,${include.regex},{{ rule }}`
       );
     }
   }


### PR DESCRIPTION
我平日习惯使用 Surgio 去统一管理多个代理源，不过 Surgio 不支持 Clash 的 rule provider 作为规则片段，所以我在原有基础上追加了生成 Surgio snippet 的部分，以便在 Surgio 中配置。

没有太考虑代码美观，就只是在原有基础上粗暴地追加生成 `.tpl` 的逻辑，有任何不妥还请指出🙏